### PR TITLE
Made everest easily runnable in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Everest uses Maven, so building from the source code is very simple. You need to
 1. Clone the repository: `git clone https://github.com/RohitAwate/Everest.git`
 2. Enter the repository: `cd Everest`
 3. Build a binary: `mvn package`
-4. Run the binary: `mvn exec:java`.
+4. Run the binary: `mvn exec:java`
 
 **For JDK  10 and above:** JavaFX has been decoupled from the JDK and will need to be installed separately.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Everest uses Maven, so building from the source code is very simple. You need to
 1. Clone the repository: `git clone https://github.com/RohitAwate/Everest.git`
 2. Enter the repository: `cd Everest`
 3. Build a binary: `mvn package`
-4. Run the binary: `java -jar target/Everest-Alpha-1.X.jar` replacing 'X' with the current version.
+4. Run the binary: `mvn exec:java`.
 
 **For JDK  10 and above:** JavaFX has been decoupled from the JDK and will need to be installed separately.
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <main.class>com.rohitawate.everest.Main</main.class>
     </properties>
     <build>
         <plugins>
@@ -45,7 +46,7 @@
                                 <!-- add Main-Class to manifest file -->
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>com.rohitawate.everest.Main</mainClass>
+                                    <mainClass>${main.class}</mainClass>
                                 </transformer>
                             </transformers>
                         </configuration>
@@ -53,6 +54,14 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <mainClass>${main.class}</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Using the exec maven plugin allow easier launch of application by just running two maven commands : `mvn package`and `mvn exec:java`.
They can even be merged `mvn package exec:java`.
It could even be simpler using a profile ...