### PR TITLE
Small bugfix and Graviton support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
     <groupId>com.rohitawate</groupId>
     <artifactId>Everest</artifactId>
     <version>Alpha-1.3</version>
+    <name>Everest</name>
+    <description>A beautiful REST workbench.</description>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -49,6 +51,8 @@
                                     <mainClass>${main.class}</mainClass>
                                 </transformer>
                             </transformers>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>bundled</shadedClassifierName>
                         </configuration>
                     </execution>
                 </executions>
@@ -60,6 +64,19 @@
                 <version>1.6.0</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Graviton-Features>inline</Graviton-Features>
+                            <Main-Class>${main.class}</Main-Class>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/rohitawate/everest/Main.java
+++ b/src/main/java/com/rohitawate/everest/Main.java
@@ -37,17 +37,16 @@ public class Main extends Application {
 
         FXMLLoader loader = new FXMLLoader(getClass().getResource("/fxml/homewindow/HomeWindow.fxml"));
         Parent homeWindow = loader.load();
-        Stage dashboardStage = new Stage();
         ThemeManager.setTheme(homeWindow);
 
         Rectangle2D screenBounds = Screen.getPrimary().getBounds();
-        dashboardStage.setWidth(screenBounds.getWidth() * 0.83);
-        dashboardStage.setHeight(screenBounds.getHeight() * 0.74);
+        primaryStage.setWidth(screenBounds.getWidth() * 0.83);
+        primaryStage.setHeight(screenBounds.getHeight() * 0.74);
 
-        dashboardStage.getIcons().add(new Image(getClass().getResource("/assets/Logo.png").toExternalForm()));
-        dashboardStage.setScene(new Scene(homeWindow));
-        dashboardStage.setTitle(APP_NAME);
-        dashboardStage.show();
+        primaryStage.getIcons().add(new Image(getClass().getResource("/assets/Logo.png").toExternalForm()));
+        primaryStage.setScene(new Scene(homeWindow));
+        primaryStage.setTitle(APP_NAME);
+        primaryStage.show();
     }
 
     public static void main(String args[]) {

--- a/src/main/java/com/rohitawate/everest/sync/SQLiteManager.java
+++ b/src/main/java/com/rohitawate/everest/sync/SQLiteManager.java
@@ -64,7 +64,7 @@ class SQLiteManager implements DataManager {
             String configPath = "Everest/config/";
             File configFolder = new File(configPath);
             if (!configFolder.exists()) {
-                if (configFolder.mkdirs())
+                if (!configFolder.mkdirs())
                     LoggingService.logSevere("Unable to create directory: " + configPath, null, LocalDateTime.now());
             }
 


### PR DESCRIPTION
Hi Rohit!

I'm the author of https://graviton.app - an experimental app browser for the JVM. I'm trying to provide an alternative to and compete with applets, Java Web Start, etc. It keeps both the JVM and the apps updated automatically and all it requires is the app to be published to a Maven repository. Or it can even run apps straight for github using jitpack.io

I love what you're doing with Everest and would like it to be a showcase app for the initial limited distribution alpha. Graviton can run apps from Maven repositories, and can run Everest as is. But with this PR I activate an opt-in feature of reusing the browser JVM and stage, so you get a seamless transition from browser shell to Everest and back again. It's maybe easier to show with a video demo:

![graviton everest](https://user-images.githubusercontent.com/971089/49106573-6c7f9580-f27b-11e8-9180-3160bfaaacfe.gif)

Unfortunately there is one step I can't do for you - you'd need to upload the (non shaded) JAR to a Maven repository like Central or JCenter. If you merge this PR and do that then Graviton will have a nice showcase app. Are you up for it?