### PR TITLE
Fix build for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <main.class>com.rohitawate.everest.Main</main.class>
     </properties>
     <build>
@@ -65,11 +65,26 @@
         </plugins>
     </build>
     <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.jfoenix/jfoenix -->
         <dependency>
             <groupId>com.jfoenix</groupId>
             <artifactId>jfoenix</artifactId>
-            <version>1.4.0</version>
+            <version>9.0.10</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
         <dependency>

--- a/src/main/java/com/rohitawate/everest/controllers/DashboardController.java
+++ b/src/main/java/com/rohitawate/everest/controllers/DashboardController.java
@@ -18,6 +18,7 @@ package com.rohitawate.everest.controllers;
 import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXProgressBar;
 import com.jfoenix.controls.JFXSnackbar;
+import com.jfoenix.controls.JFXSnackbarLayout;
 import com.rohitawate.everest.controllers.auth.AuthTabController;
 import com.rohitawate.everest.controllers.codearea.EverestCodeArea;
 import com.rohitawate.everest.controllers.codearea.highlighters.HighlighterFactory;
@@ -68,6 +69,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ResourceBundle;
+import javafx.util.Duration;
 
 public class DashboardController implements Initializable {
     @FXML
@@ -184,7 +186,8 @@ public class DashboardController implements Initializable {
             responseArea.selectAll();
             responseArea.copy();
             responseArea.deselect();
-            snackbar.show("Response body copied to clipboard.", 5000);
+            snackbar.enqueue(new JFXSnackbar.SnackbarEvent(new Label("Response body copied to clipboard."),
+                    Duration.seconds(5), null));
         });
 
         responseTypeBox.getItems().addAll(
@@ -232,7 +235,8 @@ public class DashboardController implements Initializable {
 
             if (address.equals("")) {
                 showLayer(ResponseLayer.PROMPT);
-                snackbar.show("Please enter an address.", 3000);
+                snackbar.enqueue(new JFXSnackbar.SnackbarEvent(new Label("Please enter an address."),
+                        Duration.seconds(3), null));
                 return;
             }
 
@@ -306,7 +310,8 @@ public class DashboardController implements Initializable {
             syncManager.saveState(getState().composer);
         } catch (MalformedURLException MURLE) {
             showLayer(ResponseLayer.PROMPT);
-            snackbar.show("Invalid address. Please verify and try again.", 3000);
+            snackbar.enqueue(new JFXSnackbar.SnackbarEvent(new Label("Invalid address. Please verify and try again."),
+                    Duration.seconds(3), null));
         } catch (Exception E) {
             LoggingService.logSevere("Request execution failed.", E, LocalDateTime.now());
             errorTitle.setText("Oops... That's embarrassing!");
@@ -332,7 +337,8 @@ public class DashboardController implements Initializable {
         } else if (throwable.getClass() == RedirectException.class) {
             RedirectException redirect = (RedirectException) throwable;
             addressField.setText(redirect.getNewLocation());
-            snackbar.show("Resource moved permanently. Redirecting...", 3000);
+            snackbar.enqueue(new JFXSnackbar.SnackbarEvent(new Label("Resource moved permanently. Redirecting..."),
+                    Duration.seconds(3), null));
             requestManager = null;
             sendRequest();
             return;
@@ -461,16 +467,17 @@ public class DashboardController implements Initializable {
                     case "text/html":
                         simplifiedContentType = HTTPConstants.HTML;
                         if (Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-                            snackbar.show("Open link in browser?", "YES", 5000, e -> {
-                                snackbar.close();
-                                new Thread(() -> {
-                                    try {
-                                        Desktop.getDesktop().browse(new URI(addressField.getText()));
-                                    } catch (Exception ex) {
-                                        LoggingService.logWarning("Invalid URL encountered while opening in browser.", ex, LocalDateTime.now());
-                                    }
-                                }).start();
-                            });
+                            snackbar.enqueue(new JFXSnackbar.SnackbarEvent(new JFXSnackbarLayout("Open link in browser?", "YES",
+                                    e -> {
+                                        snackbar.close();
+                                        new Thread(() -> {
+                                            try {
+                                                Desktop.getDesktop().browse(new URI(addressField.getText()));
+                                            } catch (Exception ex) {
+                                                LoggingService.logWarning("Invalid URL encountered while opening in browser.", ex, LocalDateTime.now());
+                                            }
+                                        }).start();
+                                    }), Duration.seconds(5), null));
                         }
                         break;
                     default:
@@ -490,7 +497,8 @@ public class DashboardController implements Initializable {
             responseTypeBox.setValue(simplifiedContentType);
         } catch (Exception e) {
             String errorMessage = "Response could not be parsed.";
-            snackbar.show(errorMessage, 5000);
+            snackbar.enqueue(new JFXSnackbar.SnackbarEvent(new Label(errorMessage),
+                    Duration.seconds(5), null));
             LoggingService.logSevere(errorMessage, e, LocalDateTime.now());
             errorTitle.setText("Parsing Error");
             errorDetails.setText(errorMessage);


### PR DESCRIPTION
 - Updated project dependencies
   - Added javafx-controls and javafx-fxml (OpenJFX 11)
   - Added jakarta.xml.bind-api: java.xml.bind has been removed from Java 11
   - Bumped jfoenix to 9.0.10 for Java 11 support
 - Fixed (deprecated) JFXSnackbar-related code